### PR TITLE
Fix pubspec map dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # Location and Maps
   geolocator: ^11.0.0 # For getting GPS coordinates
-  Maps_flutter: ^2.5.3 # For displaying maps
+  google_maps_flutter: ^2.5.3 # For displaying maps
 
   # UI/Utility Packages
   intl: ^0.19.0 # For date and number formatting, localization


### PR DESCRIPTION
## Summary
- use `google_maps_flutter` instead of non-existent `Maps_flutter`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5be4f238832a98070dc0e4a1d5c4