### PR TITLE
Fix build errors in admin and photographer screens

### DIFF
--- a/lib/features/admin/screens/admin_events_scheduling_screen.dart
+++ b/lib/features/admin/screens/admin_events_scheduling_screen.dart
@@ -173,6 +173,7 @@ class _AdminEventsSchedulingScreenState extends State<AdminEventsSchedulingScree
   @override
   Widget build(BuildContext context) {
     final authService = Provider.of<AuthService>(context);
+    final firestoreService = Provider.of<FirestoreService>(context, listen: false);
 
     if (authService.currentUser == null || authService.userRole != UserRole.admin) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/features/client/screens/client_rewards_screen.dart
+++ b/lib/features/client/screens/client_rewards_screen.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:share_plus/share_plus.dart'; // لتسهيل مشاركة الروابط
+import 'package:share_plus/share_plus.dart' as share_plus; // لتسهيل مشاركة الروابط
 
 import '../../../core/models/user_model.dart';
 import '../../../core/services/auth_service.dart';
@@ -78,7 +78,7 @@ class _ClientRewardsScreenState extends State<ClientRewardsScreen> {
       }
 
       // مشاركة الرابط باستخدام share_plus
-      await Share.share('مرحبًا! استخدم تطبيق Cam Touch لحجز جلسات التصوير الاحترافية. سجل الآن عبر رابط الإحالة الخاص بي لتحصل على مكافآت!\n$link');
+      await share_plus.Share.share('مرحبًا! استخدم تطبيق Cam Touch لحجز جلسات التصوير الاحترافية. سجل الآن عبر رابط الإحالة الخاص بي لتحصل على مكافآت!\n$link');
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('تم مشاركة رابط الإحالة بنجاح!')),
       );

--- a/lib/features/shared/widgets/custom_button.dart
+++ b/lib/features/shared/widgets/custom_button.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class CustomButton extends StatelessWidget {
   final String text;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   final Color? color;
   final Color? textColor;
   final EdgeInsetsGeometry? padding;


### PR DESCRIPTION
## Summary
- provide FirestoreService to AdminEventsSchedulingScreen's build
- alias share_plus and update use in ClientRewardsScreen
- allow CustomButton.onPressed to be nullable for disabling buttons

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5f94a3c4832a80fd9951626d92ca