### PR TITLE
Add scheduled status handling in admin bookings screen

### DIFF
--- a/lib/features/admin/screens/admin_bookings_management_screen.dart
+++ b/lib/features/admin/screens/admin_bookings_management_screen.dart
@@ -91,6 +91,8 @@ class AdminBookingsManagementScreen extends StatelessWidget {
         return Icons.payment;
       case 'completed':
         return Icons.done_all;
+      case 'scheduled':
+        return Icons.event_available;
       default:
         return Icons.info_outline;
     }
@@ -108,6 +110,8 @@ class AdminBookingsManagementScreen extends StatelessWidget {
         return Colors.blue;
       case 'completed':
         return Colors.purple;
+      case 'scheduled':
+        return Colors.teal;
       default:
         return Colors.grey;
     }


### PR DESCRIPTION
## Summary
- update admin bookings list to handle `scheduled` bookings

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b63a35b10832ab16c81f20fac0c7c