### PR TITLE
Fix Android build error by updating share_plus

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   intl: ^0.19.0 # For date and number formatting, localization
   provider: ^6.0.5 # A popular state management solution for Flutter
   uuid: ^4.2.2 # For generating unique identifiers (e.g., booking IDs)
-  share_plus: ^6.3.0 # For sharing referral links
+  share_plus: ^7.2.1 # For sharing referral links
 
   # PDF Generation (for invoices)
   printing: ^5.11.1 # For creating and printing PDF documents


### PR DESCRIPTION
## Summary
- update `share_plus` to a version that declares an Android namespace

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6618be5c832aa4038cce74276a43