### PR TITLE
Fix Firebase initialization error

### DIFF
--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -73,7 +73,11 @@ class NotificationService {
   // معالجة الإشعارات عند النقر عليها (والتطبيق في الخلفية/مغلق)
   static Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     // تأكد من تهيئة Firebase هنا إذا لم يكن التطبيق قيد التشغيل بالفعل
-    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
     debugPrint("Handling a background message: ${message.messageId}");
     // يمكنك القيام بمعالجة البيانات أو توجيه المستخدم إلى شاشة معينة
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,14 @@ import 'firebase_options.dart';
 // سجل دالة معالجة الإشعارات في الخلفية (يجب أن تكون خارج دالة main)
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  // Firebase might already be initialized when the app is running. Only
+  // initialize if there are no existing Firebase apps to avoid the
+  // [core/duplicate-app] exception.
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
   debugPrint("Handling a background message: ${message.messageId}");
   // يمكنك القيام بمعالجة البيانات أو توجيه المستخدم إلى شاشة معينة هنا
 }


### PR DESCRIPTION
## Summary
- avoid reinitializing Firebase when handling background messages
- guard NotificationService background handler with a check for existing Firebase apps

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687b69827f64832a8294dcf74b12ca3d