### PR TITLE
Fix photographer report imports

### DIFF
--- a/lib/features/admin/screens/reports/photographer_financial_report_screen.dart
+++ b/lib/features/admin/screens/reports/photographer_financial_report_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/models/user_model.dart';
 import '../../../../core/services/auth_service.dart';
 import '../../../../core/services/firestore_service.dart';
 import '../../../shared/widgets/loading_indicator.dart';
+import '../../../../routes/app_router.dart';
 
 class PhotographerFinancialReportScreen extends StatelessWidget {
   const PhotographerFinancialReportScreen({super.key});


### PR DESCRIPTION
## Summary
- add missing AppRouter import for PhotographerFinancialReportScreen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b917c9614832abb1ef751629ef219