### PR TITLE
Fix import for client reports

### DIFF
--- a/lib/features/admin/screens/reports/client_financial_report_screen.dart
+++ b/lib/features/admin/screens/reports/client_financial_report_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/models/user_model.dart';
 import '../../../../core/services/auth_service.dart';
 import '../../../../core/services/firestore_service.dart';
 import '../../../shared/widgets/loading_indicator.dart';
+import '../../../../routes/app_router.dart';
 
 class ClientFinancialReportScreen extends StatelessWidget {
   const ClientFinancialReportScreen({super.key});


### PR DESCRIPTION
## Summary
- fix missing AppRouter import in the client financial report

## Testing
- `dart format lib/features/admin/screens/reports/client_financial_report_screen.dart` *(fails: command not found)*
- `flutter format lib/features/admin/screens/reports/client_financial_report_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9276fed0832aa194af3b72e0b538