### PR TITLE
Add client splash screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,11 +5,12 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'core/services/auth_service.dart';
-import 'features/auth/screens/login_screen.dart'; // We will create this
-import 'features/client/screens/client_dashboard_screen.dart'; // We will create this
-import 'features/photographer/screens/photographer_dashboard_screen.dart'; // We will create this
-import 'features/admin/screens/admin_dashboard_screen.dart'; // We will create this
-import 'routes/app_router.dart'; // We will create this
+import 'features/auth/screens/login_screen.dart';
+import 'features/client/screens/client_dashboard_screen.dart';
+import 'features/client/screens/client_splash_screen.dart';
+import 'features/photographer/screens/photographer_dashboard_screen.dart';
+import 'features/admin/screens/admin_dashboard_screen.dart';
+import 'routes/app_router.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -64,16 +65,16 @@ class MyApp extends StatelessWidget {
       // Use consumer to listen to auth state and redirect accordingly
       home: Consumer<AuthService>(
         builder: (context, authService, _) {
-          // This will handle initial routing based on authentication state
-          // and user role once we implement it in AuthService.
-          // For now, it will simply go to LoginScreen.
-          // Later:
-          // if (authService.user != null) {
-          //   if (authService.userRole == 'client') return ClientDashboardScreen();
-          //   if (authService.userRole == 'photographer') return PhotographerDashboardScreen();
-          //   if (authService.userRole == 'admin') return AdminDashboardScreen();
-          // }
-          return const LoginScreen(); // Default to login screen
+          if (authService.currentUser != null) {
+            if (authService.userRole == UserRole.client) {
+              return const ClientDashboardScreen();
+            } else if (authService.userRole == UserRole.photographer) {
+              return const PhotographerDashboardScreen();
+            } else if (authService.userRole == UserRole.admin) {
+              return const AdminDashboardScreen();
+            }
+          }
+          return const ClientSplashScreen();
         },
       ),
       onGenerateRoute: AppRouter.onGenerateRoute, // For named routes

--- a/lib/features/client/screens/client_splash_screen.dart
+++ b/lib/features/client/screens/client_splash_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import '../../../core/services/auth_service.dart';
+import '../../../routes/app_router.dart';
+import '../../shared/widgets/custom_button.dart';
+
+class ClientSplashScreen extends StatelessWidget {
+  const ClientSplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(24.0),
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF024650), Color(0xFF03788A)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Image.asset('assets/img/white_logo.png', height: 120),
+            const SizedBox(height: 32),
+            const Text(
+              'مرحباً بك في Cam Touch',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 28,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'اكتشف أفضل المصورين واحجز جلساتك بلمسة واحدة.\nاكسب النقاط واستمتع بالمكافآت مع كل حجز.',
+              style: TextStyle(
+                color: Colors.white70,
+                fontSize: 18,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 40),
+            CustomButton(
+              text: 'إنشاء حساب',
+              onPressed: () {
+                Navigator.of(context).pushNamed(
+                  AppRouter.registerRoute,
+                  arguments: UserRole.client,
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed(AppRouter.loginRoute);
+              },
+              child: const Text(
+                'تسجيل الدخول',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../core/services/auth_service.dart';
 import '../features/auth/screens/login_screen.dart';
 import '../features/auth/screens/register_screen.dart';
+import '../features/client/screens/client_splash_screen.dart';
 import '../features/client/screens/client_dashboard_screen.dart';
 import '../features/photographer/screens/photographer_dashboard_screen.dart';
 import '../features/admin/screens/admin_dashboard_screen.dart';
@@ -22,6 +23,7 @@ import '../features/photographer/screens/photographer_schedule_screen.dart'; // 
 
 class AppRouter {
   static const String loginRoute = '/';
+  static const String clientSplashRoute = '/splash';
   static const String registerRoute = '/register';
   static const String clientDashboardRoute = '/client_dashboard';
   static const String photographerDashboardRoute = '/photographer_dashboard';
@@ -45,6 +47,8 @@ class AppRouter {
     switch (settings.name) {
       case loginRoute:
         return MaterialPageRoute(builder: (_) => const LoginScreen());
+      case clientSplashRoute:
+        return MaterialPageRoute(builder: (_) => const ClientSplashScreen());
       case registerRoute:
         final args = settings.arguments;
         return MaterialPageRoute(builder: (_) => RegisterScreen(initialRole: args is UserRole ? args : null));


### PR DESCRIPTION
## Summary
- add professional splash screen for clients
- add navigation route for splash screen
- show splash screen when user is not authenticated

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b997a0fc4832aaa09b7d4ed46d719