### PR TITLE
Fix login navigation from splash

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -22,7 +22,7 @@ import '../features/photographer/screens/photographer_deductions_screen.dart';
 import '../features/photographer/screens/photographer_schedule_screen.dart'; // استيراد جديد
 
 class AppRouter {
-  static const String loginRoute = '/';
+  static const String loginRoute = '/login';
   static const String clientSplashRoute = '/splash';
   static const String registerRoute = '/register';
   static const String clientDashboardRoute = '/client_dashboard';


### PR DESCRIPTION
## Summary
- ensure the splash screen navigates to `/login` instead of relaunching itself

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f619d0c832a8d6e35ea4a70afb9