### PR TITLE
Fix login debug buttons

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -156,20 +156,30 @@ class _LoginScreenState extends State<LoginScreen> {
                   const Text(
                     'تسجيل سريع (أثناء التطوير)',
                     style: TextStyle(color: Colors.grey),
+                  ),
                   const SizedBox(height: 8.0),
                   CustomButton(
                     text: 'دخول كعميل',
-                    onPressed: () => _phoneController.text=_clientPhone; _signInWithPhone(),
+                    onPressed: () {
+                      _phoneController.text = _clientPhone;
+                      _signInWithPhone();
+                    },
                   ),
                   const SizedBox(height: 8.0),
                   CustomButton(
                     text: 'دخول كمصور',
-                    onPressed: () => _phoneController.text=_photographerPhone; _signInWithPhone(),
+                    onPressed: () {
+                      _phoneController.text = _photographerPhone;
+                      _signInWithPhone();
+                    },
                   ),
                   const SizedBox(height: 8.0),
                   CustomButton(
                     text: 'دخول كمدير',
-                    onPressed: () => _phoneController.text=_adminPhone; _signInWithPhone(),
+                    onPressed: () {
+                      _phoneController.text = _adminPhone;
+                      _signInWithPhone();
+                    },
                   ),
                 ],
               ],


### PR DESCRIPTION
## Summary
- close `Text` widget parentheses in `LoginScreen`
- use code blocks for debug login buttons so multiple statements work

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba08284f4832a98368614dddb2007