### PR TITLE
Implement email-based authentication

### DIFF
--- a/lib/core/models/user_model.dart
+++ b/lib/core/models/user_model.dart
@@ -5,7 +5,8 @@ import '../services/auth_service.dart'; // لاستخدام UserRole Enum
 
 class UserModel {
   final String uid;
-  final String phoneNumber;
+  final String email;
+  final String? phoneNumber;
   final String fullName;
   final UserRole role;
   final Timestamp? createdAt;
@@ -19,7 +20,8 @@ class UserModel {
 
   UserModel({
     required this.uid,
-    required this.phoneNumber,
+    required this.email,
+    this.phoneNumber,
     required this.fullName,
     required this.role,
     this.createdAt,
@@ -33,7 +35,8 @@ class UserModel {
         doc.data() as Map<String, dynamic>? ?? <String, dynamic>{};
     return UserModel(
       uid: doc.id,
-      phoneNumber: data['phoneNumber'] as String? ?? '',
+      email: data['email'] as String? ?? '',
+      phoneNumber: data['phoneNumber'] as String?,
       fullName: data['fullName'] as String? ?? '',
       role: UserRole.values.firstWhere(
         (e) => e.toString().split('.').last == data['role'],
@@ -48,7 +51,8 @@ class UserModel {
   // لتحويل UserModel إلى Map يمكن حفظه في Firestore
   Map<String, dynamic> toFirestore() {
     return {
-      'phoneNumber': phoneNumber,
+      'email': email,
+      if (phoneNumber != null) 'phoneNumber': phoneNumber,
       'fullName': fullName,
       'role': role.toString().split('.').last,
       'createdAt': createdAt ?? FieldValue.serverTimestamp(),
@@ -61,6 +65,7 @@ class UserModel {
 
   // لتحديث حقول معينة
   UserModel copyWith({
+    String? email,
     String? phoneNumber,
     String? fullName,
     UserRole? role,
@@ -72,6 +77,7 @@ class UserModel {
   }) {
     return UserModel(
       uid: uid,
+      email: email ?? this.email,
       phoneNumber: phoneNumber ?? this.phoneNumber,
       fullName: fullName ?? this.fullName,
       role: role ?? this.role,


### PR DESCRIPTION
## Summary
- add `email` field to `UserModel` and make phone optional
- support email sign-up and login in `AuthService`
- update login screen UI for email/password auth
- update registration screen to require email/password and optional phone

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba5e08678832a91c76025565574fa