### PR TITLE
Fix login flow with explicit role refresh

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -221,6 +221,11 @@ class AuthService extends ChangeNotifier {
     await _auth.signOut();
   }
 
+  // جلب دور المستخدم الحالي يدوياً بعد تسجيل الدخول
+  Future<void> refreshUserRole() async {
+    await _updateUserRole(_auth.currentUser);
+  }
+
   // دالة داخلية لتحديث دور المستخدم بناءً على بياناته في Firestore
   Future<void> _updateUserRole(User? user) async {
     if (user == null) {

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -43,6 +43,9 @@ class _LoginScreenState extends State<LoginScreen> {
       role: role,
     );
 
+    // Ensure role is loaded before navigating
+    await authService.refreshUserRole();
+
     setState(() {
       _isLoading = false;
       _errorMessage = error;
@@ -75,6 +78,9 @@ class _LoginScreenState extends State<LoginScreen> {
       password: _passwordController.text.trim(),
     );
 
+    // Ensure role is loaded before navigating
+    await authService.refreshUserRole();
+
     setState(() {
       _isLoading = false;
       _errorMessage = error;
@@ -87,8 +93,6 @@ class _LoginScreenState extends State<LoginScreen> {
         Navigator.of(context).pushReplacementNamed(AppRouter.photographerDashboardRoute);
       } else if (authService.userRole == UserRole.admin) {
         Navigator.of(context).pushReplacementNamed(AppRouter.adminDashboardRoute);
-      } else {
-        Navigator.of(context).pushReplacementNamed(AppRouter.loginRoute);
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure role is refreshed immediately after signing in
- remove fallback navigation to login screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bba2f53b8832a8f255d2711d241d3