### PR TITLE
Handle login exception details

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -65,7 +65,7 @@ class AuthService extends ChangeNotifier {
     } on FirebaseAuthException catch (e) {
       return e.message;
     } catch (e) {
-      return 'An unknown error occurred.';
+      return e.toString();
     }
   }
 
@@ -90,7 +90,7 @@ class AuthService extends ChangeNotifier {
     } on FirebaseAuthException catch (e) {
       return e.message;
     } catch (e) {
-      return 'An unknown error occurred.';
+      return e.toString();
     }
   }
 
@@ -151,7 +151,7 @@ class AuthService extends ChangeNotifier {
     } on FirebaseAuthException catch (e) {
       return e.message;
     } catch (e) {
-      return 'An unknown error occurred.';
+      return e.toString();
     }
   }
 
@@ -181,7 +181,7 @@ class AuthService extends ChangeNotifier {
     } on FirebaseAuthException catch (e) {
       return e.message;
     } catch (e) {
-      return 'An unknown error occurred.';
+      return e.toString();
     }
   }
 
@@ -196,7 +196,7 @@ class AuthService extends ChangeNotifier {
     } on FirebaseAuthException catch (e) {
       return e.message;
     } catch (e) {
-      return 'An unknown error occurred.';
+      return e.toString();
     }
   }
 


### PR DESCRIPTION
## Summary
- show underlying exception messages in `AuthService`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbafaa4b0832a84290ef5c8302fab