### PR TITLE
Pin firebase_auth version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   # Firebase Core and Services
   firebase_core: ^2.24.2 # Core Firebase functionalities
-  firebase_auth: ^4.15.3 # User authentication
+  firebase_auth: 4.15.3 # User authentication
   cloud_firestore: ^4.13.5 # NoSQL database for data storage
   firebase_messaging: ^14.7.10 # Push notifications
   firebase_storage: ^11.5.6 # Storing files like invoices


### PR DESCRIPTION
## Summary
- fix cast issue by pinning `firebase_auth` to `4.15.3`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbc4c4000832aae826da4007ec123