### PR TITLE
Add admin client management

### DIFF
--- a/lib/core/services/firestore_service.dart
+++ b/lib/core/services/firestore_service.dart
@@ -53,6 +53,16 @@ class FirestoreService {
     }
   }
 
+  // الحصول على قائمة بجميع العملاء
+  Stream<List<UserModel>> getAllClients() {
+    return _db
+        .collection('users')
+        .where('role', isEqualTo: 'client')
+        .snapshots()
+        .map((snapshot) =>
+            snapshot.docs.map((doc) => UserModel.fromFirestore(doc)).toList());
+  }
+
   // ------------------------------------
   // Booking Management (Collection: 'bookings')
   // ------------------------------------

--- a/lib/features/admin/screens/admin_clients_management_screen.dart
+++ b/lib/features/admin/screens/admin_clients_management_screen.dart
@@ -1,0 +1,89 @@
+// lib/features/admin/screens/admin_clients_management_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/user_model.dart';
+import '../../../core/services/auth_service.dart';
+import '../../../core/services/firestore_service.dart';
+import '../../../routes/app_router.dart';
+import '../../shared/widgets/custom_app_bar.dart';
+import '../../shared/widgets/loading_indicator.dart';
+
+class AdminClientsManagementScreen extends StatelessWidget {
+  const AdminClientsManagementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final authService = Provider.of<AuthService>(context);
+    final firestoreService = Provider.of<FirestoreService>(context);
+
+    if (authService.currentUser == null || authService.userRole != UserRole.admin) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.of(context).pushReplacementNamed(AppRouter.loginRoute);
+      });
+      return const LoadingIndicator();
+    }
+
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: 'إدارة العملاء',
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.person_add),
+            onPressed: () {
+              Navigator.of(context).pushNamed(
+                AppRouter.registerRoute,
+                arguments: UserRole.client,
+              );
+            },
+            tooltip: 'إضافة عميل جديد',
+          ),
+        ],
+      ),
+      body: StreamBuilder<List<UserModel>>(
+        stream: firestoreService.getAllClients(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const LoadingIndicator();
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('خطأ: ${snapshot.error}'));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('لا يوجد عملاء لعرضهم حالياً.'));
+          }
+
+          final clients = snapshot.data!;
+          return ListView.builder(
+            itemCount: clients.length,
+            itemBuilder: (context, index) {
+              final client = clients[index];
+              return Card(
+                margin: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                child: ListTile(
+                  leading: const Icon(Icons.person),
+                  title: Text(client.fullName),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('البريد الإلكتروني: ${client.email}'),
+                      if (client.phoneNumber != null)
+                        Text('رقم الهاتف: ${client.phoneNumber}'),
+                      Text('النقاط: ${client.points}'),
+                    ],
+                  ),
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('سيتم إضافة تفاصيل العميل قريباً!')),
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/admin/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/screens/admin_dashboard_screen.dart
@@ -69,6 +69,13 @@ class AdminDashboardScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             CustomButton(
+              text: 'إدارة العملاء',
+              onPressed: () {
+                Navigator.of(context).pushNamed(AppRouter.adminClientsManagementRoute);
+              },
+            ),
+            const SizedBox(height: 16),
+            CustomButton(
               text: 'جدولة الفعاليات',
               onPressed: () {
                 Navigator.of(context).pushNamed(AppRouter.adminEventsSchedulingRoute);

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -12,6 +12,7 @@ import '../features/client/screens/booking_screen.dart';
 import '../features/admin/screens/admin_bookings_management_screen.dart';
 import '../features/admin/screens/booking_detail_screen.dart';
 import '../features/admin/screens/admin_photographers_management_screen.dart';
+import '../features/admin/screens/admin_clients_management_screen.dart';
 import '../features/admin/screens/admin_events_scheduling_screen.dart';
 import '../features/admin/screens/admin_reports_screen.dart';
 import '../features/admin/screens/reports/attendance_report_screen.dart';
@@ -32,6 +33,7 @@ class AppRouter {
   static const String adminBookingsManagementRoute = '/admin_bookings_management';
   static const String bookingDetailRoute = '/booking_detail';
   static const String adminPhotographersManagementRoute = '/admin_photographers_management';
+  static const String adminClientsManagementRoute = '/admin_clients_management';
   static const String adminEventsSchedulingRoute = '/admin_events_scheduling';
   static const String adminReportsRoute = '/admin_reports';
   static const String attendanceReportRoute = '/admin_reports/attendance';
@@ -67,6 +69,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => BookingDetailScreen(bookingId: args));
       case adminPhotographersManagementRoute:
         return MaterialPageRoute(builder: (_) => const AdminPhotographersManagementScreen());
+      case adminClientsManagementRoute:
+        return MaterialPageRoute(builder: (_) => const AdminClientsManagementScreen());
       case adminEventsSchedulingRoute:
         return MaterialPageRoute(builder: (_) => const AdminEventsSchedulingScreen());
       case adminReportsRoute:


### PR DESCRIPTION
## Summary
- add stream for fetching all clients
- create admin clients management screen
- route admin dashboard to new screen
- expose new route in AppRouter

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc59d6f78832aabb14db1d9377932