### PR TITLE
Display statuses in Arabic

### DIFF
--- a/lib/core/utils/status_utils.dart
+++ b/lib/core/utils/status_utils.dart
@@ -1,0 +1,24 @@
+const Map<String, String> bookingStatusLabels = {
+  'pending_admin_approval': 'قيد المراجعة',
+  'approved': 'موافق عليه',
+  'rejected': 'مرفوض',
+  'deposit_paid': 'دفع العربون',
+  'completed': 'مكتمل',
+  'cancelled': 'ملغي',
+  'scheduled': 'مجدول',
+};
+
+const Map<String, String> eventStatusLabels = {
+  'scheduled': 'مجدول',
+  'ongoing': 'قيد التنفيذ',
+  'completed': 'مكتمل',
+  'cancelled': 'ملغي',
+};
+
+String getBookingStatusLabel(String status) {
+  return bookingStatusLabels[status] ?? status;
+}
+
+String getEventStatusLabel(String status) {
+  return eventStatusLabels[status] ?? status;
+}

--- a/lib/features/admin/screens/admin_bookings_management_screen.dart
+++ b/lib/features/admin/screens/admin_bookings_management_screen.dart
@@ -11,6 +11,7 @@ import '../../../routes/app_router.dart';
 import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/widgets/custom_app_bar.dart';
 import 'booking_detail_screen.dart'; // سنقوم بإنشاء هذه الشاشة تالياً
+import '../../../core/utils/status_utils.dart';
 
 class AdminBookingsManagementScreen extends StatefulWidget {
   const AdminBookingsManagementScreen({super.key});
@@ -111,7 +112,7 @@ class _AdminBookingsManagementScreenState extends State<AdminBookingsManagementS
                                       size: 18,
                                     ),
                                     const SizedBox(width: 4),
-                                    Text(booking.status),
+                                    Text(getBookingStatusLabel(booking.status)),
                                   ],
                                 )),
                               ],

--- a/lib/features/admin/screens/booking_detail_screen.dart
+++ b/lib/features/admin/screens/booking_detail_screen.dart
@@ -15,6 +15,7 @@ import '../../shared/widgets/custom_button.dart';
 import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/dialogs/confirmation_dialog.dart'; // سنقوم بإنشاء هذا لاحقاً
 import '../../shared/widgets/custom_app_bar.dart';
+import '../../../core/utils/status_utils.dart';
 
 
 class BookingDetailScreen extends StatefulWidget {
@@ -414,7 +415,8 @@ class _BookingDetailScreenState extends State<BookingDetailScreen> {
               Text('المتبقي: ${(_booking!.estimatedCost - _booking!.paidAmount).toStringAsFixed(2)} ريال يمني',
                   style: const TextStyle(fontSize: 16)),
             const SizedBox(height: 8),
-            Text('الحالة: ${_booking!.status}', style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            Text('الحالة: ${getBookingStatusLabel(_booking!.status)}',
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
             if (_booking!.depositAmount != null)
               Text('مبلغ العربون: ${_booking!.depositAmount!.toStringAsFixed(2)} ريال يمني', style: const TextStyle(fontSize: 16)),

--- a/lib/features/admin/screens/reports/client_financial_report_screen.dart
+++ b/lib/features/admin/screens/reports/client_financial_report_screen.dart
@@ -13,6 +13,7 @@ import '../../../../routes/app_router.dart';
 import '../../../shared/widgets/loading_indicator.dart';
 import '../../../../routes/app_router.dart';
 import '../../../shared/widgets/custom_app_bar.dart';
+import '../../../../core/utils/status_utils.dart';
 
 class ClientFinancialReportScreen extends StatelessWidget {
   const ClientFinancialReportScreen({super.key});
@@ -78,7 +79,7 @@ class ClientFinancialReportScreen extends StatelessWidget {
                           return Text('العميل ID: ${booking.clientId}');
                         },
                       ),
-                      Text('الحالة: ${booking.status}'),
+                      Text('الحالة: ${getBookingStatusLabel(booking.status)}'),
                       Text('التكلفة المقدرة: ${booking.estimatedCost.toStringAsFixed(2)} ريال يمني'),
                       if (booking.depositAmount != null)
                         Text('العربون المدفوع: ${booking.depositAmount!.toStringAsFixed(2)} ريال يمني'),

--- a/lib/features/client/screens/client_dashboard_screen.dart
+++ b/lib/features/client/screens/client_dashboard_screen.dart
@@ -12,6 +12,7 @@ import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/widgets/custom_app_bar.dart';
 import 'booking_screen.dart'; // تأكد من هذا الاستيراد
 import 'client_rewards_screen.dart'; // استيراد جديد
+import '../../../core/utils/status_utils.dart';
 
 class ClientDashboardScreen extends StatefulWidget {
   const ClientDashboardScreen({super.key});
@@ -131,7 +132,7 @@ class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
                               const SizedBox(height: 4),
                               Text('التاريخ: ${booking.bookingDate.toLocal().toString().split(' ')[0]}'),
                               Text('الوقت: ${booking.bookingTime}'),
-                              Text('الحالة: ${booking.status}'),
+                              Text('الحالة: ${getBookingStatusLabel(booking.status)}'),
                               if (booking.photographerId != null)
                                 Text('المصور المعين ID: ${booking.photographerId}'),
                               // يمكنك إضافة زر لعرض تفاصيل الحجز أو الفاتورة هنا

--- a/lib/features/photographer/screens/photographer_dashboard_screen.dart
+++ b/lib/features/photographer/screens/photographer_dashboard_screen.dart
@@ -17,6 +17,7 @@ import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/widgets/custom_button.dart';
 import '../../shared/widgets/custom_app_bar.dart';
 import 'photographer_schedule_screen.dart'; // استيراد جديد لشاشة الجدول الزمني
+import '../../../core/utils/status_utils.dart';
 
 class PhotographerDashboardScreen extends StatefulWidget {
   const PhotographerDashboardScreen({super.key});
@@ -234,7 +235,7 @@ class _PhotographerDashboardScreenState extends State<PhotographerDashboardScree
                               const SizedBox(height: 4),
                               Text('التاريخ والوقت: ${DateFormat('yyyy-MM-dd HH:mm').format(event.eventDateTime.toLocal())}'),
                               Text('الموقع: ${event.location}'),
-                              Text('الحالة: ${event.status}'),
+                              Text('الحالة: ${getEventStatusLabel(event.status)}'),
                               Text('خصم التأخير: ${event.lateDeductionAmount.toStringAsFixed(2)} ريال يمني'),
                               Text('مدة السماح: ${event.gracePeriodMinutes} دقيقة'),
                               const SizedBox(height: 10),

--- a/lib/features/photographer/screens/photographer_schedule_screen.dart
+++ b/lib/features/photographer/screens/photographer_schedule_screen.dart
@@ -11,6 +11,7 @@ import '../../../core/services/firestore_service.dart';
 import '../../../routes/app_router.dart';
 import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/widgets/custom_app_bar.dart';
+import '../../../core/utils/status_utils.dart';
 
 class PhotographerScheduleScreen extends StatelessWidget {
   const PhotographerScheduleScreen({super.key});
@@ -66,7 +67,7 @@ class PhotographerScheduleScreen extends StatelessWidget {
                         style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 4),
-                      Text('الحالة: ${event.status}'),
+                      Text('الحالة: ${getEventStatusLabel(event.status)}'),
                       Text('التاريخ والوقت: ${DateFormat('yyyy-MM-dd HH:mm').format(event.eventDateTime.toLocal())}'),
                       Text('الموقع: ${event.location}'),
                       Text('خصم التأخير المحتمل: ${event.lateDeductionAmount.toStringAsFixed(2)} ريال يمني'),


### PR DESCRIPTION
## Summary
- add `status_utils` helper with Arabic labels
- show localized status text across dashboard and management screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd41ecc94832a8adb65bcaa9a0f8d