### PR TITLE
Enable deposit payment button on scheduled bookings

### DIFF
--- a/lib/features/admin/screens/booking_detail_screen.dart
+++ b/lib/features/admin/screens/booking_detail_screen.dart
@@ -436,7 +436,7 @@ class _BookingDetailScreenState extends State<BookingDetailScreen> {
                 color: Colors.red,
               ),
             ],
-            if (_booking!.status == 'approved') ...[
+            if (_booking!.status == 'approved' || _booking!.status == 'scheduled') ...[
               CustomButton(
                 text: 'تسجيل دفع العربون',
                 onPressed: _recordDeposit,


### PR DESCRIPTION
## Summary
- display the **Record deposit** button when the booking status is either `approved` or `scheduled`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd847e098832abbadc9e51a0d421f