### PR TITLE
Add photographer accounts management

### DIFF
--- a/lib/core/models/booking_model.dart
+++ b/lib/core/models/booking_model.dart
@@ -21,6 +21,7 @@ class BookingModel {
   final String? paymentProofUrl; // رابط صورة إثبات الدفع
   final String? invoiceUrl; // رابط الفاتورة
   final double paidAmount; // اجمالي المبلغ المدفوع
+  final Map<String, double>? photographerPayments; // المبالغ المدفوعة لكل مصور
   final Timestamp createdAt;
   final Timestamp? updatedAt;
 
@@ -43,6 +44,7 @@ class BookingModel {
     this.invoiceUrl,
     required this.createdAt,
     this.updatedAt,
+    this.photographerPayments,
   });
 
   factory BookingModel.fromFirestore(DocumentSnapshot doc) {
@@ -64,6 +66,7 @@ class BookingModel {
       paymentProofUrl: data['paymentProofUrl'],
       invoiceUrl: data['invoiceUrl'],
       paidAmount: (data['paidAmount'] as num?)?.toDouble() ?? 0.0,
+      photographerPayments: (data['photographerPayments'] as Map?)?.map((k, v) => MapEntry(k as String, (v as num).toDouble())),
       createdAt: data['createdAt'] as Timestamp,
       updatedAt: data['updatedAt'] as Timestamp?,
     );
@@ -86,6 +89,7 @@ class BookingModel {
       'paymentProofUrl': paymentProofUrl,
       'invoiceUrl': invoiceUrl,
       'paidAmount': paidAmount,
+      'photographerPayments': photographerPayments,
       'createdAt': createdAt,
       'updatedAt': FieldValue.serverTimestamp(), // يتم تحديثه عند كل تعديل
     };
@@ -107,6 +111,7 @@ class BookingModel {
     String? paymentProofUrl,
     String? invoiceUrl,
     double? paidAmount,
+    Map<String, double>? photographerPayments,
     Timestamp? createdAt,
     Timestamp? updatedAt,
   }) {
@@ -127,6 +132,7 @@ class BookingModel {
       paymentProofUrl: paymentProofUrl ?? this.paymentProofUrl,
       invoiceUrl: invoiceUrl ?? this.invoiceUrl,
       paidAmount: paidAmount ?? this.paidAmount,
+      photographerPayments: photographerPayments ?? this.photographerPayments,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/features/admin/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/screens/admin_dashboard_screen.dart
@@ -69,6 +69,14 @@ class AdminDashboardScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             CustomButton(
+              text: 'إدارة حسابات المصورين',
+              onPressed: () {
+                Navigator.of(context).pushNamed(AppRouter.adminPhotographerAccountsRoute);
+              },
+              color: Colors.deepPurple,
+            ),
+            const SizedBox(height: 16),
+            CustomButton(
               text: 'إدارة العملاء',
               onPressed: () {
                 Navigator.of(context).pushNamed(AppRouter.adminClientsManagementRoute);

--- a/lib/features/admin/screens/admin_photographer_accounts_screen.dart
+++ b/lib/features/admin/screens/admin_photographer_accounts_screen.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/booking_model.dart';
+import '../../../core/models/user_model.dart';
+import '../../../core/services/auth_service.dart';
+import '../../../core/services/firestore_service.dart';
+import '../../../routes/app_router.dart';
+import '../../shared/widgets/custom_app_bar.dart';
+import '../../shared/widgets/loading_indicator.dart';
+
+class AdminPhotographerAccountsScreen extends StatefulWidget {
+  const AdminPhotographerAccountsScreen({super.key});
+
+  @override
+  State<AdminPhotographerAccountsScreen> createState() => _AdminPhotographerAccountsScreenState();
+}
+
+class _AdminPhotographerAccountsScreenState extends State<AdminPhotographerAccountsScreen> {
+  String _search = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final authService = Provider.of<AuthService>(context);
+    final firestoreService = Provider.of<FirestoreService>(context);
+
+    if (authService.currentUser == null || authService.userRole != UserRole.admin) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.of(context).pushReplacementNamed(AppRouter.loginRoute);
+      });
+      return const LoadingIndicator();
+    }
+
+    return Scaffold(
+      appBar: const CustomAppBar(title: 'إدارة حسابات المصورين'),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              decoration: const InputDecoration(
+                labelText: 'بحث',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onChanged: (val) => setState(() => _search = val),
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<List<BookingModel>>(
+              stream: firestoreService.getAllBookings(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const LoadingIndicator();
+                }
+                if (snapshot.hasError) {
+                  return Center(child: Text('خطأ: ${snapshot.error}'));
+                }
+                if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                  return const Center(child: Text('لا توجد حجوزات'));
+                }
+
+                final bookings = snapshot.data!
+                    .where((b) => b.photographerIds != null && b.photographerIds!.isNotEmpty)
+                    .where((b) {
+                      if (_search.isEmpty) return true;
+                      final q = _search.toLowerCase();
+                      return b.clientName.toLowerCase().contains(q) ||
+                          b.serviceType.toLowerCase().contains(q);
+                    }).toList();
+
+                if (bookings.isEmpty) {
+                  return const Center(child: Text('لا توجد نتائج'));
+                }
+
+                return ListView.builder(
+                  itemCount: bookings.length,
+                  itemBuilder: (context, index) {
+                    final booking = bookings[index];
+                    return Card(
+                      margin: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'الخدمة: ${booking.serviceType} - ${DateFormat('yyyy-MM-dd').format(booking.bookingDate)}',
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 8),
+                            ...booking.photographerIds!.map((pid) {
+                              return FutureBuilder<UserModel?>(
+                                future: firestoreService.getUser(pid),
+                                builder: (context, userSnapshot) {
+                                  final name = userSnapshot.data?.fullName ?? pid;
+                                  final paid = booking.photographerPayments?[pid] ?? 0.0;
+                                  return ListTile(
+                                    contentPadding: EdgeInsets.zero,
+                                    title: Text('المصور: $name'),
+                                    subtitle: Text('المدفوع: ${paid.toStringAsFixed(2)} ريال يمني'),
+                                    trailing: TextButton(
+                                      onPressed: () async {
+                                        final controller = TextEditingController();
+                                        final amount = await showDialog<double>(
+                                          context: context,
+                                          builder: (_) => AlertDialog(
+                                            title: const Text('إدخال المبلغ'),
+                                            content: TextField(
+                                              controller: controller,
+                                              keyboardType: TextInputType.number,
+                                              decoration: const InputDecoration(labelText: 'المبلغ'),
+                                            ),
+                                            actions: [
+                                              TextButton(
+                                                onPressed: () => Navigator.pop(context),
+                                                child: const Text('إلغاء'),
+                                              ),
+                                              TextButton(
+                                                onPressed: () {
+                                                  final val = double.tryParse(controller.text);
+                                                  Navigator.pop(context, val);
+                                                },
+                                                child: const Text('حفظ'),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                        if (amount != null) {
+                                          await firestoreService.recordPhotographerPayment(booking.id, pid, amount);
+                                        }
+                                      },
+                                      child: const Text('دفع'),
+                                    ),
+                                  );
+                                },
+                              );
+                            }).toList(),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/photographer/screens/photographer_dashboard_screen.dart
+++ b/lib/features/photographer/screens/photographer_dashboard_screen.dart
@@ -9,6 +9,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../core/services/auth_service.dart';
 import '../../../core/services/firestore_service.dart';
 import '../../../core/services/location_service.dart';
+import '../../../core/models/booking_model.dart';
 import '../../../core/models/event_model.dart';
 import '../../../core/models/attendance_model.dart';
 import '../../../core/models/photographer_model.dart';
@@ -280,6 +281,44 @@ class _PhotographerDashboardScreenState extends State<PhotographerDashboardScree
                               ),
                             ],
                           ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'حجوزاتك والمدفوعات:',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: StreamBuilder<List<BookingModel>>(
+                stream: firestoreService.getPhotographerBookings(authService.currentUser!.uid),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const LoadingIndicator();
+                  }
+                  if (snapshot.hasError) {
+                    return Center(child: Text('خطأ: ${snapshot.error}'));
+                  }
+                  if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                    return const Center(child: Text('لا توجد حجوزات حالياً.'));
+                  }
+
+                  final bookings = snapshot.data!;
+                  return ListView.builder(
+                    itemCount: bookings.length,
+                    itemBuilder: (context, index) {
+                      final booking = bookings[index];
+                      final paid = booking.photographerPayments?[authService.currentUser!.uid] ?? 0.0;
+                      return Card(
+                        margin: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+                        child: ListTile(
+                          title: Text('${booking.serviceType} - ${DateFormat('yyyy-MM-dd').format(booking.bookingDate)}'),
+                          subtitle: Text('المدفوع لك: ${paid.toStringAsFixed(2)} ريال يمني'),
                         ),
                       );
                     },

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -16,6 +16,7 @@ import '../features/admin/screens/admin_photographers_management_screen.dart';
 import '../features/admin/screens/admin_clients_management_screen.dart';
 import '../features/admin/screens/admin_events_scheduling_screen.dart';
 import '../features/admin/screens/admin_reports_screen.dart';
+import '../features/admin/screens/admin_photographer_accounts_screen.dart';
 import '../features/admin/screens/reports/attendance_report_screen.dart';
 import '../features/admin/screens/reports/photographer_financial_report_screen.dart';
 import '../features/admin/screens/reports/client_financial_report_screen.dart';
@@ -38,6 +39,7 @@ class AppRouter {
   static const String adminClientsManagementRoute = '/admin_clients_management';
   static const String adminEventsSchedulingRoute = '/admin_events_scheduling';
   static const String adminReportsRoute = '/admin_reports';
+  static const String adminPhotographerAccountsRoute = '/admin_photographer_accounts';
   static const String attendanceReportRoute = '/admin_reports/attendance';
   static const String photographerFinancialReportRoute =
       '/admin_reports/photographers_financial';
@@ -79,6 +81,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const AdminEventsSchedulingScreen());
       case adminReportsRoute:
         return MaterialPageRoute(builder: (_) => const AdminReportsScreen());
+      case adminPhotographerAccountsRoute:
+        return MaterialPageRoute(builder: (_) => const AdminPhotographerAccountsScreen());
       case attendanceReportRoute:
         return MaterialPageRoute(builder: (_) => const AttendanceReportScreen());
       case photographerFinancialReportRoute:


### PR DESCRIPTION
## Summary
- track photographer payments per booking
- handle photographer payment transactions
- add photographer accounts management screen for admins
- show photographer payments on their dashboard
- wire up new route and dashboard entry

## Testing
- `dart` and `flutter` commands are unavailable in the environment, so formatting and tests could not run

------
https://chatgpt.com/codex/tasks/task_e_687cd969144c832a906cfd7aa2b704e1