### PR TITLE
Show user's full name on dashboard

### DIFF
--- a/lib/features/admin/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/screens/admin_dashboard_screen.dart
@@ -12,9 +12,33 @@ import 'admin_photographers_management_screen.dart';
 // لجدولة المواعيد الخاصة بالفعاليات
 import 'admin_events_scheduling_screen.dart';
 import 'admin_reports_screen.dart';
+import '../../../core/services/firestore_service.dart';
+import '../../../core/models/user_model.dart';
 
-class AdminDashboardScreen extends StatelessWidget {
+class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({super.key});
+
+  @override
+  State<AdminDashboardScreen> createState() => _AdminDashboardScreenState();
+}
+
+class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
+  UserModel? _adminUser;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAdminUser();
+  }
+
+  Future<void> _loadAdminUser() async {
+    final authService = Provider.of<AuthService>(context, listen: false);
+    final firestoreService = Provider.of<FirestoreService>(context, listen: false);
+    if (authService.currentUser != null) {
+      _adminUser = await firestoreService.getUser(authService.currentUser!.uid);
+      if (mounted) setState(() {});
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +69,7 @@ class AdminDashboardScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'مرحبًا بك يا ${authService.currentUser?.email ?? 'مدير'}!',
+              'مرحبًا بك يا ${_adminUser?.fullName ?? authService.currentUser?.email ?? 'مدير'}!',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 20),

--- a/lib/features/client/screens/client_dashboard_screen.dart
+++ b/lib/features/client/screens/client_dashboard_screen.dart
@@ -23,23 +23,23 @@ class ClientDashboardScreen extends StatefulWidget {
 }
 
 class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
-  // يمكننا جلب بيانات العميل هنا إذا أردنا عرض اسمه
-  // UserModel? _clientUser;
+  // متغير لتخزين بيانات العميل لجلب الاسم الكامل
+  UserModel? _clientUser;
 
   @override
   void initState() {
     super.initState();
-    // _loadClientData(); // يمكن تفعيل هذا لاسترداد بيانات العميل
+    _loadClientData(); // جلب بيانات العميل لعرض اسمه
   }
 
-  // Future<void> _loadClientData() async {
-  //   final authService = Provider.of<AuthService>(context, listen: false);
-  //   final firestoreService = Provider.of<FirestoreService>(context, listen: false);
-  //   if (authService.currentUser != null) {
-  //     _clientUser = await firestoreService.getUser(authService.currentUser!.uid);
-  //     setState(() {});
-  //   }
-  // }
+  Future<void> _loadClientData() async {
+    final authService = Provider.of<AuthService>(context, listen: false);
+    final firestoreService = Provider.of<FirestoreService>(context, listen: false);
+    if (authService.currentUser != null) {
+      _clientUser = await firestoreService.getUser(authService.currentUser!.uid);
+      if (mounted) setState(() {});
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -73,7 +73,7 @@ class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'مرحبًا بك يا ${authService.currentUser?.email ?? 'عميل'}!',
+              'مرحبًا بك يا ${_clientUser?.fullName ?? authService.currentUser?.email ?? 'عميل'}!',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 20),

--- a/lib/features/photographer/screens/photographer_dashboard_screen.dart
+++ b/lib/features/photographer/screens/photographer_dashboard_screen.dart
@@ -30,11 +30,13 @@ class PhotographerDashboardScreen extends StatefulWidget {
 class _PhotographerDashboardScreenState extends State<PhotographerDashboardScreen> {
   PhotographerModel? _photographerData;
   String? _errorMessage;
+  UserModel? _photographerUser;
 
   @override
   void initState() {
     super.initState();
     _loadPhotographerData();
+    _loadUserData();
   }
 
   Future<void> _loadPhotographerData() async {
@@ -42,7 +44,16 @@ class _PhotographerDashboardScreenState extends State<PhotographerDashboardScree
     final firestoreService = Provider.of<FirestoreService>(context, listen: false);
     if (authService.currentUser != null) {
       _photographerData = await firestoreService.getPhotographerData(authService.currentUser!.uid);
-      setState(() {});
+      if (mounted) setState(() {});
+    }
+  }
+
+  Future<void> _loadUserData() async {
+    final authService = Provider.of<AuthService>(context, listen: false);
+    final firestoreService = Provider.of<FirestoreService>(context, listen: false);
+    if (authService.currentUser != null) {
+      _photographerUser = await firestoreService.getUser(authService.currentUser!.uid);
+      if (mounted) setState(() {});
     }
   }
 
@@ -169,7 +180,7 @@ class _PhotographerDashboardScreenState extends State<PhotographerDashboardScree
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'مرحبًا بك يا ${authService.currentUser?.email ?? 'مصور'}!',
+              'مرحبًا بك يا ${_photographerUser?.fullName ?? authService.currentUser?.email ?? 'مصور'}!',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- display user's full name on client dashboard welcome message
- fetch photographer name for dashboard greeting
- convert admin dashboard to `StatefulWidget` to load admin name and show it in greeting

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cdbe26744832aa0ba25606b4a9ce2