### PR TITLE
Fix syntax error in admin photographer accounts screen

### DIFF
--- a/lib/features/admin/screens/admin_photographer_accounts_screen.dart
+++ b/lib/features/admin/screens/admin_photographer_accounts_screen.dart
@@ -93,12 +93,11 @@ class _AdminPhotographerAccountsScreenState extends State<AdminPhotographerAccou
                               style: const TextStyle(fontWeight: FontWeight.bold),
                             ),
                             const SizedBox(height: 8),
-                            final ids = booking.photographerIds ??
+                            for (final pid in booking.photographerIds ??
                                 (booking.photographerId != null
                                     ? [booking.photographerId!]
-                                    : <String>[]);
-                            ...ids.map((pid) {
-                              return FutureBuilder<UserModel?>(
+                                    : <String>[]))
+                              FutureBuilder<UserModel?>(
                                 future: firestoreService.getUser(pid),
                                 builder: (context, userSnapshot) {
                                   final name = userSnapshot.data?.fullName ?? pid;
@@ -142,8 +141,7 @@ class _AdminPhotographerAccountsScreenState extends State<AdminPhotographerAccou
                                     ),
                                   );
                                 },
-                              );
-                            }).toList(),
+                              ),
                           ],
                         ),
                       ),


### PR DESCRIPTION
## Summary
- fix invalid inline variable assignment by using a `for` loop to build photographer widgets

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_687ce0416e28832a9d60923fa72d5334