### PR TITLE
Add date-based filter to photographer accounts

### DIFF
--- a/lib/core/services/firestore_service.dart
+++ b/lib/core/services/firestore_service.dart
@@ -141,6 +141,20 @@ class FirestoreService {
         .map((snapshot) => snapshot.docs.map((doc) => BookingModel.fromFirestore(doc)).toList());
   }
 
+  /// Retrieves all bookings that occur on the given [date].
+  Stream<List<BookingModel>> getBookingsByDate(DateTime date) {
+    final start = DateTime(date.year, date.month, date.day);
+    final end = start.add(const Duration(days: 1));
+    return _db
+        .collection('bookings')
+        .where('bookingDate', isGreaterThanOrEqualTo: Timestamp.fromDate(start))
+        .where('bookingDate', isLessThan: Timestamp.fromDate(end))
+        .orderBy('bookingDate')
+        .snapshots()
+        .map((snapshot) =>
+            snapshot.docs.map((doc) => BookingModel.fromFirestore(doc)).toList());
+  }
+
   // ------------------------------------
   // Photographer Management (Collection: 'photographers_data')
   // ------------------------------------


### PR DESCRIPTION
## Summary
- allow filtering bookings by date in photographer accounts screen
- display detailed booking info for admins
- support date-based Firestore query with `getBookingsByDate`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce69f7f4c832a9cc55312e62bcf9d