### PR TITLE
Fix photographer payment balance logic

### DIFF
--- a/lib/core/services/firestore_service.dart
+++ b/lib/core/services/firestore_service.dart
@@ -231,7 +231,8 @@ class FirestoreService {
 
       if (photographerSnap.exists) {
         txn.update(photographerRef, {
-          'balance': FieldValue.increment(amount),
+          // reduce the remaining balance when a payment is made
+          'balance': FieldValue.increment(-amount),
         });
       }
     });


### PR DESCRIPTION
## Summary
- fix photographer balance update when recording a payment

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce825484c832a827c84e40fb45093