### PR TITLE
Add Firestore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ firebase deploy --only functions
 You can verify that `processPhotographerCheckIn` runs by checking the
 Firebase Console logs after creating an `attendance_records` document.
 
+
+## Firestore Security Rules
+
+The `firestore.rules` file contains development rules that allow any authenticated user to read and write all documents. Deploy these rules with:
+
+```bash
+firebase deploy --only firestore:rules
+```
+
+These permissive rules are intended for local testing. Review and tighten them before releasing the app.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Allow read/write to authenticated users
+    match /bookings/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+    match /events/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+    match /photographers_data/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+    match /attendance_records/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+    match /users/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+    // Default rule for other collections
+    match /{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add default Firestore security rules
- document how to deploy the rules in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cf1d0325c832ab5e28ebc072bce16