### PR TITLE
Add confirmation dialog on logout

### DIFF
--- a/lib/features/admin/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/screens/admin_dashboard_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/services/auth_service.dart';
 import '../../../routes/app_router.dart';
 import '../../shared/widgets/custom_button.dart';
 import '../../shared/widgets/custom_app_bar.dart';
+import '../../shared/dialogs/confirmation_dialog.dart';
 import 'admin_bookings_management_screen.dart';
 // لاستعراض وإدارة بيانات المصورين
 import 'admin_photographers_management_screen.dart';
@@ -57,7 +58,16 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
           IconButton(
             icon: const Icon(Icons.logout),
             onPressed: () async {
-              await authService.signOut();
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (context) => const ConfirmationDialog(
+                  title: 'تأكيد تسجيل الخروج',
+                  content: 'هل أنت متأكد أنك تريد تسجيل الخروج؟',
+                ),
+              );
+              if (confirm == true) {
+                await authService.signOut();
+              }
             },
           ),
         ],

--- a/lib/features/client/screens/client_dashboard_screen.dart
+++ b/lib/features/client/screens/client_dashboard_screen.dart
@@ -11,6 +11,7 @@ import '../../../routes/app_router.dart';
 import '../../shared/widgets/custom_button.dart';
 import '../../shared/widgets/loading_indicator.dart';
 import '../../shared/widgets/custom_app_bar.dart';
+import '../../shared/dialogs/confirmation_dialog.dart';
 import 'booking_screen.dart'; // تأكد من هذا الاستيراد
 import 'client_rewards_screen.dart'; // استيراد جديد
 import '../../../core/utils/status_utils.dart';
@@ -62,7 +63,16 @@ class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
           IconButton(
             icon: const Icon(Icons.logout),
             onPressed: () async {
-              await authService.signOut();
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (context) => const ConfirmationDialog(
+                  title: 'تأكيد تسجيل الخروج',
+                  content: 'هل أنت متأكد أنك تريد تسجيل الخروج؟',
+                ),
+              );
+              if (confirm == true) {
+                await authService.signOut();
+              }
             },
           ),
         ],

--- a/lib/features/photographer/screens/photographer_dashboard_screen.dart
+++ b/lib/features/photographer/screens/photographer_dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../../shared/widgets/custom_button.dart';
 import '../../shared/widgets/custom_app_bar.dart';
 import 'photographer_schedule_screen.dart'; // استيراد جديد لشاشة الجدول الزمني
 import '../../../core/utils/status_utils.dart';
+import '../../shared/dialogs/confirmation_dialog.dart';
 
 class PhotographerDashboardScreen extends StatefulWidget {
   const PhotographerDashboardScreen({super.key});
@@ -190,7 +191,16 @@ class _PhotographerDashboardScreenState extends State<PhotographerDashboardScree
           IconButton(
             icon: const Icon(Icons.logout),
             onPressed: () async {
-              await authService.signOut();
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (context) => const ConfirmationDialog(
+                  title: 'تأكيد تسجيل الخروج',
+                  content: 'هل أنت متأكد أنك تريد تسجيل الخروج؟',
+                ),
+              );
+              if (confirm == true) {
+                await authService.signOut();
+              }
             },
             tooltip: 'تسجيل الخروج',
           ),


### PR DESCRIPTION
## Summary
- show confirmation dialog before logging out on admin, client, and photographer dashboards

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d086264f0832aa5d85d4fd74a09bf