### PR TITLE
fix: update Android compile SDK to 33

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,9 @@ plugins {
 
 android {
     namespace = "com.cam.touch.cam_touch_app"
-    compileSdk = flutter.compileSdkVersion
+    // Explicitly set the compileSdk version to resolve
+    // resource linking issues with newer Android attributes
+    compileSdk = 33
     ndkVersion = flutter.ndkVersion
     
     // Fix for printing plugin compatibility
@@ -44,7 +46,8 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        // Target the same API level as the compileSdk for consistency
+        targetSdk = 33
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }


### PR DESCRIPTION
## Summary
- pin compile SDK to 33 to support new Android attributes
- align target SDK with compile SDK

## Testing
- `flutter build apk --debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2d6d0e14832a92f1a40998eaa93f