### PR TITLE
chore(android): update to compile sdk 34

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,7 +9,7 @@ android {
     namespace = "com.cam.touch.cam_touch_app"
     // Explicitly set the compileSdk version to resolve
     // resource linking issues with newer Android attributes
-    compileSdk = 33
+    compileSdk = 34
     ndkVersion = flutter.ndkVersion
     
     // Fix for printing plugin compatibility
@@ -47,7 +47,7 @@ android {
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         // Target the same API level as the compileSdk for consistency
-        targetSdk = 33
+        targetSdk = 34
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
- bump Android compile & target SDKs to 34
- upgrade Android Gradle plugin and Kotlin versions
- update Gradle wrapper to 8.4

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `gradle app:checkReleaseAarMetadata` *(fails: /workspace/cam_touch/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_689f32cab9f0832aa7ba7c1403e88622